### PR TITLE
Implement blocking recv function for Receiver

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -167,6 +167,13 @@ impl<T> Receiver<T> {
             Ok(res)
         })
     }
+
+    pub fn recv(&self) -> Result<T, mpsc::RecvError> {
+        self.rx.recv().and_then(|res| {
+            let _ = self.ctl.dec();
+            Ok(res)
+        })
+    }
 }
 
 impl<T> Evented for Receiver<T> {


### PR DESCRIPTION
I'm not sure if this operation is safe but I thought if `try_recv()` is safe this should be safe too. I'd appreciate it if you could take a look @carllerche .