### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ exclude       = [
 mio = "0.6"
 log = "0.3.1"
 lazycell = "0.5"
-slab = "0.3.0"
+slab = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ exclude       = [
 [dependencies]
 mio = "0.6"
 log = "0.3.1"
-lazycell = "0.4.0"
+lazycell = "0.5"
 slab = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,6 @@ mod convert {
     pub fn millis(duration: Duration) -> u64 {
         // Round up.
         let millis = (duration.subsec_nanos() + NANOS_PER_MILLI - 1) / NANOS_PER_MILLI;
-        duration.as_secs().saturating_mul(MILLIS_PER_SEC).saturating_add(millis as u64)
+        duration.as_secs().saturating_mul(MILLIS_PER_SEC).saturating_add(u64::from(millis))
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -372,7 +372,7 @@ impl<T> Evented for Timer<T> {
         poll.register(&registration, token, interest, opts)?;
         let wakeup_state = Arc::new(AtomicUsize::new(usize::MAX));
         let thread_handle = spawn_wakeup_thread(
-            wakeup_state.clone(),
+            Arc::clone(&wakeup_state),
             set_readiness.clone(),
             self.start, self.tick_ms);
 
@@ -381,7 +381,7 @@ impl<T> Evented for Timer<T> {
             set_readiness: set_readiness,
             wakeup_state: wakeup_state,
             wakeup_thread: thread_handle,
-        }).ok().expect("timer already registered");
+        }).expect("timer already registered");
 
         if let Some(next_tick) = self.next_tick() {
             self.schedule_readiness(next_tick);


### PR DESCRIPTION
Update dependencies, deal with deprecations, appease clippy.

Additionally, since `slab.insert()` no longer fails, there is no longer any source of `TimerError`s and so I have retired them.