### PR TITLE
Transfer carllerche/mio#591

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -54,6 +54,15 @@ struct Inner {
     wakeup_thread: thread::JoinHandle<()>,
 }
 
+impl Drop for Inner {
+    fn drop(&mut self) {
+        // 1. Set wakeup state to TERMINATE_THREAD
+        self.wakeup_state.store(TERMINATE_THREAD, Ordering::Release);
+        // 2. Wake him up
+        self.wakeup_thread.thread().unpark();
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 struct WheelEntry {
     next_tick: Tick,


### PR DESCRIPTION
I was surprised to see that there was a fix in the carllerche/mio version of this code that's not in here: carllerche/mio#591.  This pull request copies that fix over.

I'd have thought that it only makes sense to be maintaining at most one of these implementations; and if it's going to be at least one then it ought to be the one that has a future - which is to say, I suppose that fixes ought to go into this repository and not into the code that's explicitly deprecated and intended for removal...?